### PR TITLE
Add git hook

### DIFF
--- a/.rusty-hook.toml
+++ b/.rusty-hook.toml
@@ -1,0 +1,7 @@
+[hooks]
+post-commit = "echo 'Thank you for your commit.'"
+pre-push = "cargo test && cargo test --manifest-path typescript-definitions-derive/Cargo.toml && cargo fmt -- --check && cargo fmt --manifest-path typescript-definitions-derive/Cargo.toml && cargo clippy && cargo clippy --manifest-path typescript-definitions-derive/Cargo.toml"
+post-push = "echo 'Thank you for pushing.'"
+
+[logging]
+verbose = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ insta = { version="0.6" }
 chrono = { version = "0.4", features = ["serde"] }
 arrayvec = { version="0.5.1", features = ["serde"] }
 # compiletest_rs = "*"
-
+rusty-hook = "^0.11.2"
 
 [features]
 test = ["typescript-definitions-derive/test"]


### PR DESCRIPTION
This uses `rusty-hook` to manage the git hooks. To enable it, please run `cargo test` in the main directory once. This will give you a test + fmt check + clippy before pushing and also thank you for your commit + push (because I like my tools courteous :smile:)